### PR TITLE
Add optional configmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 weaviate/charts
 weaviate/weaviate-*.tgz
 weaviate/weaviate.tgz
+tmp/*

--- a/weaviate/Chart.yaml
+++ b/weaviate/Chart.yaml
@@ -1,5 +1,5 @@
 name: weaviate
-version: 10.1.0
+version: 10.2.0
 apiVersion: v1
 appVersion: v0.22.7
 home: https://github.com/semi-technologies/weaviate

--- a/weaviate/templates/deployment.yaml
+++ b/weaviate/templates/deployment.yaml
@@ -50,4 +50,4 @@ spec:
       volumes:
         - name: weaviate-config
           configMap:
-            name: weaviate-config
+            {{ if .Values.custom_config_map.enabled }}name: {{ .Values.custom_config_map.name }} {{ else }}name: weaviate-config{{ end }}

--- a/weaviate/templates/weaviateConfigMap.yaml
+++ b/weaviate/templates/weaviateConfigMap.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.custom_config_map.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,3 +23,4 @@ data:
     vector_index:
       enabled: {{ .Values.vector_index.enabled }}
       url: http://esvector-master:9200
+{{ end }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -44,7 +44,8 @@ vector_index:
   # must be enabled since 0.20.x, there is no non-vector alternative anymore
   enabled: true
 
-
+# It is also possible to configure authentication and authorization through a custom configmap
+# The authorization and authentication values defined in values.yaml will be ignored when defining a custom config map.
 custom_config_map:
   enabled: false
   name: "custom-config"

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -45,6 +45,9 @@ vector_index:
   enabled: true
 
 
+custom_config_map:
+  enabled: false
+  name: "custom-config"
 
 
 # Sub Chart Overrides


### PR DESCRIPTION
very simple additon in the `values.yaml`  https://github.com/semi-technologies/weaviate-helm/blob/add-optional-configmap/weaviate/values.yaml#L49-L51

Next to the values for authentication and authorization a custom config map also needs to contain other values like service discovery info. This is maybe not the most end user friendly but should do for now. 