### PR TITLE
Add collector proxy as option to weavaite chart, bump up chart version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ Documentation can be found [here](https://www.semi.technology/documentation/weav
 1. Wait for Travis to complete, it will create a drafted release with the
    packaged chart attached
 1. Edit the draft to include useful release notes and publish when appropriate
+
+

--- a/weaviate/Chart.yaml
+++ b/weaviate/Chart.yaml
@@ -1,5 +1,5 @@
 name: weaviate
-version: 10.2.0
+version: 10.3.0
 apiVersion: v1
 appVersion: v0.22.7
 home: https://github.com/semi-technologies/weaviate

--- a/weaviate/templates/collectorProxyConfigMap.yaml
+++ b/weaviate/templates/collectorProxyConfigMap.yaml
@@ -1,0 +1,41 @@
+{{ if .Values.collector_proxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-proxy-nginx-conf
+  namespace: {{ .Release.Namespace }}
+data:
+  nginx.conf: |
+    user  nginx;
+    worker_processes  1;
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        include                 /etc/nginx/mime.types;
+        default_type            application/octet-stream;
+        log_format              weaviate-enterprise     '$time_local|$request_method|$request_uri|$bytes_sent|$request_time|$status|$request_length';
+        sendfile                on;
+        keepalive_timeout       65;
+        client_body_buffer_size 128M;
+        client_max_body_size    128M;
+        server {
+            listen 8080 default_server;
+            listen [::]:8080 default_server;
+            error_page 500 502 503 504 /weaviate_50x.html;
+            location = /weaviate_50x.html {
+                root /usr/share/nginx/html;
+                internal;
+            }
+            # send all locations through directly
+            location / {
+                access_log /var/log/weaviate.log  weaviate-enterprise;
+                proxy_pass http://{{ .Values.service.name }}.{{ .Release.Namespace }}.svc.cluster.local:80;
+            }
+        }
+    }
+{{ end }}

--- a/weaviate/templates/collectorProxyDeployment.yaml
+++ b/weaviate/templates/collectorProxyDeployment.yaml
@@ -1,0 +1,42 @@
+{{ if .Values.collector_proxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-collector-proxy
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: enterprise-collector-proxy
+  template:
+    metadata:
+      labels:
+        app: enterprise-collector-proxy
+    spec:
+      containers:
+        - name: enterprise-collector-proxy
+          image: 'semitechnologies/weaviate-enterprise-usage-collector:{{ .Values.collector_proxy.tag }}'
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+          - name: weaviate_enterprise_token
+            value: {{ .Values.collector_proxy.weaviate_enterprise_token }}
+          - name: weaviate_enterprise_project
+            value: {{ .Values.collector_proxy.weaviate_enterprise_project }}
+          volumeMounts:
+          - name: nginx-conf
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: collector-proxy-nginx-conf
+{{ end }}

--- a/weaviate/templates/collectorProxyService.yaml
+++ b/weaviate/templates/collectorProxyService.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.collector_proxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.collector_proxy.service.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: {{ .Values.collector_proxy.service.type }}
+  selector:
+    app: enterprise-collector-proxy
+  ports:
+    - protocol: TCP
+      port: {{ .Values.collector_proxy.service.port }}
+      targetPort: 8080
+{{ end }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -152,6 +152,20 @@ contextionary:
       cpu: "1000m"
       memory: "5000Mi"
 
+# The collector proxy collects meta data over the requests.
+# It deploys a second service that, if used, will capture meta data over the incoming requests.
+# The collected data may be used to optimize the software or detect mallicious attacks.
+collector_proxy:
+  enabled: false
+  tag: latest
+  weaviate_enterprise_token: ""
+  weaviate_enterprise_project: ""
+  service:
+    name: "usage-proxy"
+    port: 80
+    type: LoadBalancer
+
+
 # The service controls how weaviate is exposed to the outside world. If you
 # don't want a public load balancer, you can also choose 'ClusterIP' to make
 # weaviate only accessible within your cluster.


### PR DESCRIPTION
I tested it against one of my clusters. 

It can be configured over the values yaml:

```
collector_proxy:
  enabled: false
  tag: latest
  weaviate_enterprise_token: ""
  weaviate_enterprise_project: ""
  service:
    name: "usage-proxy"
    port: 80
    type: LoadBalancer
```

If enabled there are 3 new resources created:
- The deployment for the collector
- The service for the collector
- The configmap for the collector