### PR TITLE
feat (chart): Add startup probe option, expand probes adjustments.

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -24,7 +24,7 @@ spec:
         {{- with .Values.command }}
         command: {{ toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.args }} 
+        {{- with .Values.args }}
         args: {{ toYaml . | nindent 10 }}
         {{- end }}
         resources:
@@ -112,12 +112,18 @@ spec:
             port: 8080
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
             path: /v1/.well-known/ready
             port: 8080
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
       volumes:
         - name: weaviate-config
           configMap:

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -106,6 +106,17 @@ spec:
             mountPath: /weaviate-config
           - name: weaviate-data
             mountPath: /var/lib/weaviate
+        {{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: /v1/.well-known/ready
+            port: 8080
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /v1/.well-known/live

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -61,7 +61,17 @@ service:
   # optionally set cluster IP if you want to set a static IP
   clusterIP:
 
-# Adjust liveness and readiness configuration
+# Adjust liveness, readiness and startup probes configuration
+startupProbe:
+  # For kubernetes versions prior to 1.18 startupProbe is not supported thus can be disabled.
+  enabled: false
+
+  initialDelaySeconds: 300
+  periodSeconds: 60
+  failureThreshold: 50
+  successThreshold: 1
+  timeoutSeconds: 3
+
 livenessProbe:
   initialDelaySeconds: 900
   periodSeconds: 60

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -74,17 +74,17 @@ startupProbe:
 
 livenessProbe:
   initialDelaySeconds: 900
-  periodSeconds: 60
-  failureThreshold: 10
+  periodSeconds: 10
+  failureThreshold: 30
   successThreshold: 1
-  timeoutSeconds: 45
+  timeoutSeconds: 3
 
 readinessProbe:
-  initialDelaySeconds: 30
-  periodSeconds: 20
+  initialDelaySeconds: 3
+  periodSeconds: 10
   failureThreshold: 3
   successThreshold: 1
-  timeoutSeconds: 10
+  timeoutSeconds: 3
 
 # Weaviate Config
 #

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -64,10 +64,17 @@ service:
 # Adjust liveness and readiness configuration
 livenessProbe:
   initialDelaySeconds: 900
-  periodSeconds: 3
+  periodSeconds: 60
+  failureThreshold: 10
+  successThreshold: 1
+  timeoutSeconds: 45
+
 readinessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  failureThreshold: 3
+  successThreshold: 1
+  timeoutSeconds: 10
 
 # Weaviate Config
 #


### PR DESCRIPTION
I've noticed on a big dataset (100gb+) when a sudden crash happens (with a single replica install), we get into a state where it takes long time to recover from `*.wal` files (last took ~30minutes), and existing livenessProbe settings put statefulSet into endless restart cycle. I would expect MTTR to grow simultaneously with a dataset. Kubernetes 1.18 introduced startupProbe that allows us to wait longer for the pod to become available before the application of the readiness/liveness routines.
It's disabled by default not to confuse users setting up fresh instance with slow start, but can be enabled for more loaded case, also expanded probes adjustments.