### PR TITLE
Allow for per-module pod scheduling hints

### DIFF
--- a/weaviate/Chart.yaml
+++ b/weaviate/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 14.2.0
+version: 14.3.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/weaviate/templates/collectorProxyDeployment.yaml
+++ b/weaviate/templates/collectorProxyDeployment.yaml
@@ -53,16 +53,16 @@ spec:
         - name: nginx-conf
           configMap:
             name: collector-proxy-nginx-conf
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "collector_proxy" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "collector_proxy" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "collector_proxy" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
-      {{- end }}          
+      {{- end }}
 {{ end }}

--- a/weaviate/templates/contextionaryDeployment.yaml
+++ b/weaviate/templates/contextionaryDeployment.yaml
@@ -32,15 +32,15 @@ spec:
             value: {{ index .Values "modules" "text2vec-contextionary" "envconfig" "enable_compound_splitting" | quote }}
         resources:
 {{ index .Values "modules" "text2vec-contextionary" "resources" | toYaml | indent 10 }}
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "text2vec-contextionary" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "text2vec-contextionary" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "text2vec-contextionary" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/weaviate/templates/img2vecNeuralDeployment.yaml
+++ b/weaviate/templates/img2vecNeuralDeployment.yaml
@@ -42,15 +42,15 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "img2vec-neural" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "img2vec-neural" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "img2vec-neural" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/weaviate/templates/multi2vecClipDeployment.yaml
+++ b/weaviate/templates/multi2vecClipDeployment.yaml
@@ -42,15 +42,15 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "multi2vec-clip" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "multi2vec-clip" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "multi2vec-clip" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/weaviate/templates/nerTransformersDeployment.yaml
+++ b/weaviate/templates/nerTransformersDeployment.yaml
@@ -42,15 +42,15 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "ner-transformers" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "ner-transformers" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "ner-transformers" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/weaviate/templates/qnaTransformersDeployment.yaml
+++ b/weaviate/templates/qnaTransformersDeployment.yaml
@@ -42,15 +42,15 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "qna-transformers" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "qna-transformers" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "qna-transformers" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/weaviate/templates/textSpellcheckDeployment.yaml
+++ b/weaviate/templates/textSpellcheckDeployment.yaml
@@ -42,15 +42,15 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "text-spellcheck" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "text-spellcheck" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "text-spellcheck" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/weaviate/templates/transformersInferenceDeployment.yaml
+++ b/weaviate/templates/transformersInferenceDeployment.yaml
@@ -42,15 +42,15 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3
-      {{- with .Values.nodeSelector }}
+      {{- with index .Values "modules" "text2vec-transformers" "nodeSelector" | default .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with index .Values "modules" "text2vec-transformers" "affinity" | default .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with index .Values "modules" "text2vec-transformers" "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -146,6 +146,20 @@ modules:
         cpu: '1000m'
         memory: '5000Mi'
 
+    # You can guide where the pods are scheduled on a per-module basis,
+    # as well as for Weaviate overall. Each module accepts nodeSelector,
+    # tolerations, and affinity configuration. If it is set on a per-
+    # module basis, this configuration overrides the global config.
+
+    nodeSelector: {}
+
+    tolerations:
+      - key: "my-example-key"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+    affinity: {}
+
   # The text2vec-transformers modules uses neural networks, such as BERT,
   # DistilBERT, etc. to dynamically compute vector embeddings based on the
   # sentence's context. It is very slow on CPUs and should run with


### PR DESCRIPTION
## Reason for the change

As discussed with @etiennedi:

`values.yaml` currently allows for `nodeSelector`, `affinity`, and `tolerations` configuration which affects how k8s schedules **all** pods in the Weaviate chart.

However, as workloads have quite different hardware needs (e.g. GPUs while building the index; lots of memory while serving requests), it would be useful to be able to direct scheduling on a per module basis.

## Change details
- Add `nodeSelector`, `affinity`, and `tolerations` sections to each of the modules' deployment files
- We fall back to the global configuration if no per-module configuration is supplied
- Change `values.yaml` to document the new functionality and show an example

## Possible problems / critiques
It could be argued we should merge global and per-module scheduler configuration. However, overriding is more expressive because any global settings can be **removed** on a per-module basis, rather than just adding. It's also possible to simply duplicate global config in the modules' configuration.

I have left `weaviateStatefulset.yaml` as **only** using the global scheduler configuration. It's possible to change this – e.g. with a new `scheduler` configuration key as a peer to `modules` – but this seemed like a larger change I'd like feedback on from the maintainers, and not something which we require. Happy to add it though.