### PR TITLE
Making the probes' initiaDelaySeconds configurable for the text2vec-transformers module

### DIFF
--- a/weaviate/templates/transformersInferenceDeployment.yaml
+++ b/weaviate/templates/transformersInferenceDeployment.yaml
@@ -34,14 +34,14 @@ spec:
           httpGet:
             path: /.well-known/live
             port: 8080
-          initialDelaySeconds: 120
+          initialDelaySeconds: {{ index .Values "modules" "text2vec-transformers" "probeInitialDelaySeconds" }}
           periodSeconds: 3
           timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /.well-known/ready
             port: 8080
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ index .Values "modules" "text2vec-transformers" "probeInitialDelaySeconds" }}
           periodSeconds: 3
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -166,6 +166,7 @@ modules:
     registry: docker.io
     replicas: 1
     fullnameOverride: transformers-inference
+    probeInitialDelaySeconds: 120
     envconfig:
       # enable for CUDA support. Your K8s cluster needs to be configured
       # accordingly and you need to explicitly set GPU requests & limits below


### PR DESCRIPTION
For those of us who are building our custom text2vec-transformer models, the probes' initialDelaySeconds might need to be adjusted (increased), as some of these models can be really heavy to load.

The readinessProbe's initialDelaySeconds being hard-coded to 3 seconds was especially an issue, so I have made the initial delay configurable for the two probes of the text2vec-transformers module, so anybody can adjust them depending on the load time of their transformer models.