### PR TITLE
Fixing gh77 - Missing support for Prometheus scraping

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -119,6 +119,11 @@ spec:
             value: {{ .Values.service.name }}-headless.{{ .Release.Namespace }}.svc.cluster.local
         ports:
           - containerPort: 8080
+          {{- if .Values.env.PROMETHEUS_MONITORING_ENABLED }}
+          - name: metrics
+            containerPort: 2112
+            protocol: TCP
+          {{- end }}
         volumeMounts:
           - name: weaviate-config
             mountPath: /weaviate-config

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -111,6 +111,9 @@ env:
   # The aggressiveness of the Go Garbage Collector. 100 is the default value.
   GOGC: 100
 
+  # Expose metrics on port 2112 for Prometheus to scrape
+  PROMETHEUS_MONITORING_ENABLED: false
+
 envSecrets:
 
 # modules are extensions to Weaviate, they can be used to support various


### PR DESCRIPTION
Fixes #77 - Weaviate v1.14.0 supports Prometheus scraping, so you can have Grafana dashboards to monitor Weaviate.

Unfortunately for Prometheus to be able to scrape the exposed endpoint (/metrics on port 2112), that port need to be added to the StatefulSet's container port.
This changes adds that container port (2112) to the Helm chart, in case the `PROMETHEUS_MONITORING_ENABLED` env variable is set to true (which is the same env variable the Weaviate app watches out for).

Once that env variable is set, to setup the Prometheus scarping config to discover your Weaviate endpoints (assuming it is running in the `weaviate` namespace), add the following to your Prometheus config:
```
      - job_name: weaviate
        scrape_interval: 5s
        scrape_timeout: 5s
        scheme: http
        metrics_path: /metrics
        # see more options at https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
        # and https://github.com/prometheus/prometheus/blob/099df0c5f00c45c007a9779a2e4ab51cf4d076bf/config/config.go#L1026-L1037
        kubernetes_sd_configs:
          - role: pod
            namespaces:
              names:
                - weaviate
        relabel_configs:
          - source_labels: [__meta_kubernetes_pod_container_port_number]
            action: keep
            regex: 2112
```